### PR TITLE
Do not extend Forwardable

### DIFF
--- a/lib/pres/presenter.rb
+++ b/lib/pres/presenter.rb
@@ -2,18 +2,23 @@
 # Construct with object, view_context, and optional options
 module Pres
   class Presenter
-    extend Forwardable
     include Presents
     include ViewDelegation
 
     attr_reader :object, :options
 
-    def_delegators :object, :id, :to_partial_path
-
     def initialize(object, view_context = nil, options = {})
       @object = object
       @view_context = view_context
       @options = options
+    end
+
+    def id
+      object.id
+    end
+
+    def to_partial_path
+      object.to_partial_path
     end
   end
 end


### PR DESCRIPTION
Instead, add simple instance methods.

Extending Forwardable adds a .delegate method, which could conflict
with Rails' .delegate method in subclasses.