### PR TITLE
Add Presenter#inspect

### DIFF
--- a/lib/pres/presenter.rb
+++ b/lib/pres/presenter.rb
@@ -22,5 +22,13 @@ module Pres
     def to_partial_path
       object.to_partial_path
     end
+
+    def inspect
+      [
+        object.inspect,
+        "options: #{options.inspect}",
+        "view_context: #{view_context.class.name}"
+      ].join("\n")
+    end
   end
 end

--- a/test/presenter_test.rb
+++ b/test/presenter_test.rb
@@ -29,4 +29,26 @@ describe Pres::Presenter do
     presenter = Pres::Presenter.new(nil)
     assert presenter.respond_to?(:present, true)
   end
+
+  it "#inspect with object" do
+    object = Object.new
+    presenter = Pres::Presenter.new(object)
+    assert_equal "#{object.inspect}\noptions: {}\nview_context: NilClass",
+      presenter.inspect
+  end
+
+  it "#inspect with options" do
+    object = Object.new
+    presenter = Pres::Presenter.new(object, nil, name: "x")
+    assert_equal %(#{object.inspect}\noptions: {:name=>"x"}\nview_context: NilClass),
+      presenter.inspect
+  end
+
+  it "#inspect with view_context" do
+    object = Object.new
+    view_context = { abc: 123 }
+    presenter = Pres::Presenter.new(object, view_context)
+    assert_equal "#{object.inspect}\noptions: {}\nview_context: Hash",
+      presenter.inspect
+  end
 end


### PR DESCRIPTION
Add a custom #inspect method, so that presenter classes can be sensibly viewed in a debug session. Before this change, the Rails view_context object would spit out hundreds of lines.